### PR TITLE
Add support for Laravel's translator

### DIFF
--- a/src/Dark/SmartyView/Smarty/libs/plugins/block.t.php
+++ b/src/Dark/SmartyView/Smarty/libs/plugins/block.t.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Smarty plugin to make use of the Laravel translator
+ */
+
+/**
+ * Smarty {t}{/t} block plugin
+ *
+ * Type:     block function<br>
+ * Name:     t<br>
+ * Purpose:  provides access to Laravel's translator<br>
+ * Params:
+ * <pre>
+ * - _count         - used for pluralization
+ * </pre>
+ * All other params are passed to Laravel's translator as replacements
+ *
+ * @param array                    $params   parameters
+ * @param string                   $content  contents of the block
+ * @param Smarty_Internal_Template $template template object
+ * @param boolean                  &$repeat  repeat flag
+ * @return string content translated
+ * @author Jakob Gahde <j5lx@fmail.co.uk>
+ */
+function smarty_block_t($params, $content, $template, &$repeat)
+{
+    if (is_null($content)) {
+        return;
+    }
+
+    if (array_key_exists('_count', $params)) {
+        $count = $params['_count'];
+        unset($params['_count']);
+
+        $translated = Lang::choice($content, $count, $params);
+    } else {
+        $translated = Lang::get($content, $params);
+    }
+
+    return $translated;
+}


### PR DESCRIPTION
I added a Smarty plugin to support Laravel’s translator. It's base syntax is inspired by smarty3-i18n:

```
{t}messages.welcome{/t}
```

If the parameter `_count` is given, pluralization is used:

```
{t _count="10"}messages.apples{/t}
```

All other parameters are passed to Laravel's translator as replacements:

```
{t name="Dayle"}messages.welcome{/t}
```
