### PR TITLE
Add support for Laravel's URL and link helper functions

### DIFF
--- a/src/Dark/SmartyView/Smarty/libs/plugins/function.link_to.php
+++ b/src/Dark/SmartyView/Smarty/libs/plugins/function.link_to.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Smarty plugin to make use of Laravel's link_to helper functions
+ */
+
+/**
+ * Smarty {link_to} plugin
+ *
+ * Type:     function<br>
+ * Name:     link_to<br>
+ * Purpose:  access Laravel's link_to helper functions
+ *
+ * @author Jakob Gahde <j5lx@fmail.co.uk>
+ * @param array                    $params   parameters
+ * @param Smarty_Internal_Template $template template object
+ * @return string|null if the assign parameter is passed, Smarty assigns the result to a template variable
+ */
+function smarty_function_link_to($params, $template)
+{
+
+    $title = array_get($params, '_title', null);
+    unset($params['_title']);
+
+    $targetTypes = array('action', 'asset', 'route', 'url');
+    $functionName = null;
+    $target = null;
+    foreach ($targetTypes as $targetType) {
+        if (!is_null($params[$targetType])) {
+            $functionName = 'link_to_' . $targetType;
+            $target = $params[$targetType];
+            unset($params[$targetType]);
+            break;
+        }
+    }
+
+    if (is_null($functionName)) {
+        throw new SmartyException("{link_to} needs exactly one of the following params: " . implode(', ', $targetTypes));
+    }
+
+    if ($functionName == 'link_to_url') {
+        $functionName = 'link_to';
+    }
+
+    if ($functionName == 'link_to_asset' || $functionName == 'link_to') {
+        $secure = array_get($params, 'secure', null);
+        unset($params['secure']);
+
+        $value = $functionName($target, $title, $params, $secure);
+    } else {
+        $parameters = $attributes = array();
+        foreach ($params as $key => $value) {
+            if (starts_with($key, 'param_')) {
+                $key = ltrim($key, 'param_');
+                $parameters[$key] = $value;
+            }
+            if (starts_with($key, 'attrib_')) {
+                $key = ltrim($key, 'attrib_');
+                $attributes[$key] = $value;
+            }
+        }
+
+        $value = $functionName($target, $title, $parameters, $attributes);
+    }
+
+    if (!empty($params['assign'])) {
+        $template->assign($params['assign'], $value);
+    } else {
+        return $value;
+    }
+}

--- a/src/Dark/SmartyView/Smarty/libs/plugins/function.url.php
+++ b/src/Dark/SmartyView/Smarty/libs/plugins/function.url.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Smarty plugin to make use of Laravel's URL helper functions
+ */
+
+/**
+ * Smarty {url} plugin
+ *
+ * Type:     function<br>
+ * Name:     url<br>
+ * Purpose:  access Laravel's URL helper functions
+ *
+ * @author Jakob Gahde <j5lx@fmail.co.uk>
+ * @param array                    $params   parameters
+ * @param Smarty_Internal_Template $template template object
+ * @return string|null if the assign parameter is passed, Smarty assigns the result to a template variable
+ */
+function smarty_function_url($params, $template)
+{
+
+    $targetTypes = array('action', 'asset', 'route', 'url');
+    $functionName = null;
+    $target = null;
+    foreach ($targetTypes as $targetType) {
+        if (!is_null($params[$targetType])) {
+            $functionName = $targetType;
+            $target = $params[$targetType];
+            unset($params[$targetType]);
+            break;
+        }
+    }
+
+    if (is_null($functionName)) {
+        throw new SmartyException("{url} needs exactly one of the following params: " . implode(', ', $targetTypes));
+    }
+
+    if ($functionName == 'asset') {
+        $secure = array_get($params, 'secure', null);
+        unset($params['secure']);
+
+        $value = asset($target, $secure);
+    } elseif ($functionName == 'url') {
+        $secure = array_get($params, 'secure', null);
+        unset($params['secure']);
+
+        $value = url($target, $params, $secure);
+    } else {
+        $value = $functionName($target, $params);
+    }
+
+    if (!empty($params['assign'])) {
+        $template->assign($params['assign'], $value);
+    } else {
+        return $value;
+    }
+}


### PR DESCRIPTION
I wrote two Smarty plugins for [Laravel's URL and link helper functions](http://laravel.com/docs/helpers#urls), `{url}` for `action()`, `route()`, `asset()` and `url()` and `{link_to}` for `link_to()`, `link_to_asset()`, `link_to_route()` and `link_to_action()`.
##### Usage Examples

In all cases the `assign` parameter can be used to assign the return value to a given template variable instead of outputting it.
###### {url}

```
{* for url() *}
{url url="…" some_param="…"}

{* for url() (secure) *}
{url url="…" some_param="…" secure=true}

{* for asset() *}
{url asset="…"}

{* for asset() (secure) *}
{url asset="…" secure=true}

{* for route() and action() *}
{url route="…"  some_param="…"}
{url action="…" some_param="…"}
```
###### {link_to}

```
{* for link_to() and link_to_asset() *}
{link_to url="…" _title="Tag Content" some_param="…"}
{link_to asset="…" _title="Tag Content" some_param="…"}

{* for link_to() and link_to_asset() (secure) *}
{link_to url="…" _title="Tag Content" some_param="…" secure=true}
{link_to asset="…" _title="Tag Content" some_param="…" secure=true}

{* for link_to_route() and link_to_action() *}
{link_to route="…" _title="Tag Content" param_some_param="…" attrib_some_attribute="…"}
{link_to action="…" _title="Tag Content" param_some_param="…" attrib_some_attribute="…"}
```
